### PR TITLE
UX-438 Namespace event emitter to prevent cross tab/window events

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,4 +1,4 @@
-import bus from './pagebus';
+import createBus from './pagebus';
 
 function removeSpaces(str) {
   return str.split(' ').join('-');
@@ -109,6 +109,10 @@ export class Libby {
   }
 
   _startEvents() {
+    // Pulls a unique id from the parent window to namespace the event emitter
+    // See: src/ui/index.js
+    const bus = createBus(window.parent.document.getElementById('sync_id').getAttribute('data-id'));
+
     bus.emit('set_entries', this._getMetadata());
 
     bus.on('load_entry', (search) => {

--- a/src/api/pagebus.js
+++ b/src/api/pagebus.js
@@ -1,6 +1,7 @@
 import createBus from 'page-bus';
 
-const bus = createBus(`libby-react`);
-bus.setMaxListeners(100);
-
-export default bus;
+export default function (id) {
+  const bus = createBus(`libby-react-${id}`);
+  bus.setMaxListeners(100);
+  return bus;
+}

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -5,7 +5,7 @@ import Theme from '@sweatpants/theme';
 import Box from '@sweatpants/box';
 import styled from 'styled-components';
 import { theme } from './theme';
-import bus from '../api/pagebus';
+import createBus from '../api/pagebus';
 import BackgroundContext, { BackgroundContextProvider } from './context/BackgroundContext';
 import SearchContext from './context/SearchContext';
 import useWindowEvent from './hooks/useWindowEvent';
@@ -29,6 +29,12 @@ function App() {
 
   const environment = useWindow();
   const searchString = environment?.location?.search;
+
+  const bus = React.useMemo(() => {
+    // Pulls a unique id from the parent window to namespace the event emitter
+    // See: src/ui/index.js
+    return createBus(document.getElementById('sync_id').getAttribute('data-id'));
+  }, []);
 
   bus.on('set_entries', (d) => {
     setInitialized(true);

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -3,6 +3,13 @@ import ReactDOM from 'react-dom';
 import App from './App';
 
 const out = document.createElement('div');
+
+// Creates a unique ID
+// Namespaces the event emitter to prevent cross tab or window events
+// This is defined here so that both the UI and Preview iframe have access to it
+out.id = 'sync_id';
+out.setAttribute('data-id', new Date().getTime());
+
 document.body.append(out);
 
 const style = document.createElement('style');


### PR DESCRIPTION
Whats Changed
- Fixes a bug that broke the event emitter with multiple windows / tabs open
- Adds a namespace of `new Date().getTime()` to the `page-bus` instance

How to verify:
- Run the example locally
  - `cd example`
  - `npm run start`
- Open libby in multiple windows, and verify navigation and rendering works as expected